### PR TITLE
Level-wise filter to viz data.

### DIFF
--- a/backend/app/views/functional.py
+++ b/backend/app/views/functional.py
@@ -1023,6 +1023,12 @@ def search(current_user):
         if source == "visualize":
             root_label = communities[community_id]['name'] if query == "" else query
 
+            # Get levels filter info
+            if request.args.get("levelfilter"):
+                levels = request.args.get("levelfilter").split(";")
+            else:
+                levels = ["topics", "hashtags", "metadescs"]
+
             for i in range(10, total_num_results, 10):
                 _, additional_results = cache_search(query, search_id, i/10, rc_dict, user_id=user_id_str,
                                                     own_submissions=own_submissions, toggle_webpage_results=toggle_webpage_results,
@@ -1033,13 +1039,10 @@ def search(current_user):
 
             # Call TopicMap
             data_ip = json.dumps(search_results_page)
-            tm = TopicMap(data_ip, root_label)
+            tm = TopicMap(data_ip, root_label, levels)
             tm.pre_process()
-            tm.extract_keywords()
-            tm.extract_metadesc_per_topic_keywords()
-            tm.sequence()
-            graphData = tm.generate_graph_data()
-
+            op_dict = tm.generate_map(0)
+            graphData = tm.generate_graph_json(op_dict)
             return response.success(graphData, Status.OK)
         return response.success(return_obj, Status.OK)
     except Exception as e:

--- a/frontend/website/components/communitybox.js
+++ b/frontend/website/components/communitybox.js
@@ -128,7 +128,8 @@ export default function CommunityBox(props) {
       pathname: "/visualizemap",
       query: {
         community: props.communityId,
-        communityName: props.name
+        communityName: props.name,
+        levelfilter: "hashtags;topics;metadescs"
       }
     });
   }

--- a/frontend/website/components/forms/searchBarHeader.js
+++ b/frontend/website/components/forms/searchBarHeader.js
@@ -85,12 +85,13 @@ function searchBarHeader(props) {
             return
         }
         if(router.asPath.includes("visualizemap"))
-            window.location = "/visualizemap?query=" + encodeURIComponent(inputValue) + "&community=all";
+            window.location = "/visualizemap?query=" + encodeURIComponent(inputValue) + "&community=all&levelfilter=hashtags;topics;metadescs";
         Router.push({
             pathname: "/visualizemap",
             query: {
                 query: encodeURIComponent(inputValue),
-                community: "all"
+                community: "all",
+                levelfilter: "hashtags;topics;metadescs"
             },
         });
     }
@@ -148,9 +149,11 @@ function searchBarHeader(props) {
                                                 },
                                             }}
                                             >
-                                                <SearchIcon />
+                                                <Tooltip title={"Search"}>
+                                                    <SearchIcon />
+                                                </Tooltip>
                                             </IconButton>
-                                            <IconButton
+                                            { inputValue.length > 0 && <IconButton
                                             variant="contained"
                                             onClick={handleVisualizeCommunity}
                                             sx={{
@@ -169,12 +172,15 @@ function searchBarHeader(props) {
                                                 },
                                             }}
                                             >
-                                                <BubbleChartIcon
+                                                <Tooltip title={"Visualize"}>
+                                                    <BubbleChartIcon
                                                     style={{marginLeft: "5px", marginRight: "5px"}}
                                                     size="medium"
 
                                                  />
+                                                </Tooltip>
                                             </IconButton>
+                                            }
                                         </>
                                     ),
                                     style: {

--- a/frontend/website/components/visualizecomponent.js
+++ b/frontend/website/components/visualizecomponent.js
@@ -14,9 +14,12 @@ import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
 import SearchResult from "./searchresult";
 import Head from "next/head";
 import Footer from "./footer";
+import {Alert, Box, Button, FormControlLabel, FormGroup, FormHelperText, FormLabel, Snackbar} from "@mui/material";
+import Checkbox from "@mui/material/Checkbox";
+import FormControl from "@mui/material/FormControl";
+import FilterAltIcon from '@mui/icons-material/FilterAlt';
 
 const baseURL_client = process.env.NEXT_PUBLIC_FROM_CLIENT + "api/";
-
 const graphRoot2 = "Loading...";
 const graphData2 = {
     "nodes": [
@@ -32,7 +35,13 @@ const graphData2 = {
         },
     ],
     "links": []
-}
+};
+const levelMap = {
+    "communities": "Communities",
+    "hashtags": "Hashtags",
+    "topics": "Topics",
+    "metadescs": "Meta-descriptors"
+};
 
 const VisualizeMap = () => {
     const router = useRouter();
@@ -40,10 +49,14 @@ const VisualizeMap = () => {
     let cid = "";
     let cn = "";
     let q = "";
+    let filter = "";
+    let arr = [];
     if (obj != undefined || obj != null || obj != "") {
         cid = obj["community"]
         cn = obj["communityName"]
         q = obj["query"]
+        filter = obj["levelfilter"];
+        arr = filter.split(';');
     }
     const [isClient, setIsClient] = useState(false);
     const [communityId, setCommunityId] = useState(cid);
@@ -62,13 +75,57 @@ const VisualizeMap = () => {
         md_name: "",
         submission_list: [],
     });
+    const [checkState, setCheckState] = useState({
+        communities: false,
+        hashtags: false,
+        topics: false,
+        metadescs: false
+    });
+    const {communities, hashtags, topics, metadescs} = checkState;
+    const [filterOrder, setFilterOrder] = useState(arr);
+    const error = [communities, hashtags, topics, metadescs].filter((v) => v).length < 1;
+    const [levelView, setLevelView] = useState("")
+
+    // Necessary States for Alert Message
+    const [open, setOpen] = useState(false);
+    const [message, setMessage] = useState("");
+    const [severity, setSeverity] = useState("error");
+    const handleClick = () => {
+        setOpen(true);
+    };
+    const handleClose = (event, reason) => {
+        if (reason === "clickaway") {
+          return;
+        }
+        setOpen(false);
+    };
+
+    const updateFilterOrderList = () => {
+        let newState = {};
+        Object.keys(checkState).forEach(key => {
+            newState[key] = checkState[key];
+        })
+        for(let fil of filterOrder) {
+            newState[fil] = true;
+        }
+        setCheckState(newState);
+        updateLevelView();
+    };
+
+    const updateLevelView = () => {
+        let op = [];
+        for(let itr of filterOrder) {
+            op.push(levelMap[itr]);
+        }
+        setLevelView(op.join(" > "));
+    };
 
     const getCommunityDocuments = async () => {
         let url; //= baseURL_client + "search?community=" + communityId + "&source=visualize&query=" + query;
-        if(communityId == "all")
-            url = baseURL_client + "search?query=" + query + "&community=all&source=visualize";
+        if (communityId == "all")
+            url = baseURL_client + "search?query=" + query + "&community=all&source=visualize&levelfilter=" + filterOrder.join(";");
         else
-            url = baseURL_client + "search?community=" + communityId + "&source=visualize";
+            url = baseURL_client + "search?community=" + communityId + "&source=visualize&levelfilter=" + filterOrder.join(";");
         const res = await fetch(url, {
             method: "GET",
             headers: new Headers({
@@ -78,14 +135,17 @@ const VisualizeMap = () => {
         });
         const response = await res.json();
         if (response.status === "ok") {
-            if(communityId == "all")
+            if (communityId == "all")
                 setRootId(query);
             else
                 setRootId(communityName);
             setGraphData(response);
             createNodeByIdMap(response);
         } else {
-            // console.log(response);
+            setSeverity("error");
+            setMessage(response.message);
+            handleClick();
+            return;
         }
     }
 
@@ -111,6 +171,7 @@ const VisualizeMap = () => {
     useEffect(() => {
         setIsClient(true);
         if (jsCookie.get("token") != undefined) {
+            updateFilterOrderList();
             getCommunityDocuments();
             setHeight(window.innerHeight);
             let canvasWidth = window.innerWidth; //- 0.01 * window.innerWidth
@@ -123,6 +184,10 @@ const VisualizeMap = () => {
             });
         }
     }, []);
+
+    useEffect(() => {
+        updateLevelView();
+    }, [checkState]);
 
     const getPrunedTree = useCallback(() => {
         const visibleNodes = [];
@@ -158,19 +223,21 @@ const VisualizeMap = () => {
             switch (node.type) {
                 case "root":
                     return "#E27429";
-                case "lecture":
+                case "hashtags":
                     return "#5F9EA0";
-                case "topic":
+                case "topics":
                     return "#CC1D7C";
-                case "meta-descriptor":
+                case "metadescs":
                     return "#964B00";
+                case "communities":
+                    return "#1876d2"
                 default:
                     return "red";
             }
         };
 
         const handleNodeClick = useCallback((node) => {
-            if (node.type == "meta-descriptor") {
+            if (node.type === filterOrder[filterOrder.length-1]) {
                 if (prevNodeId == undefined) {
                     if (!isModalOpen) {
                         setIsModalOpen(true);
@@ -295,6 +362,38 @@ const VisualizeMap = () => {
         }
     };
 
+    const handleCheckBoxChange = (e) => {
+        if(!!e.target.checked) {
+            setFilterOrder([...filterOrder, e.target.name]);
+        }
+        else {
+            let l = [...filterOrder];
+            setFilterOrder(l.filter(function(i) { return i !== e.target.name }));
+        }
+        //Update the state of the checkbox
+        setCheckState({
+            ...checkState,
+            [e.target.name]: e.target.checked,
+        });
+    };
+
+    const handleFilterOnClick = (e) => {
+        if(!!error) {
+            setSeverity("error");
+            setMessage("Check at least one Checkbox!");
+            handleClick();
+            return;
+        }
+        let url = router.pathname;
+        if(!!router.query["query"]) {
+            url += "?query=" + router.query["query"] + "&community=all" + "&levelfilter=" + filterOrder.join(";");
+        }
+        else {
+            url += "?community=" + router.query["community"] + "&communityName=" + router.query["communityName"] + "&levelfilter=" + filterOrder.join(";");
+        }
+        window.location = url;
+    };
+
     return (
         <>
             <Head>
@@ -303,7 +402,69 @@ const VisualizeMap = () => {
             </Head>
             <Header/>
             {isClient ? (
-                <div className="graph" id="graph-outer-div" style={{display: "flex"}}>
+                <div className="graph" id="graph-outer-div"
+                     style={{display: "flex", position: "relative", zIndex: "1"}}>
+                    <Box id={"filter-div"}
+                         style={{
+                             marginTop: "70px",
+                             marginLeft: "1%",
+                             zIndex: "2",
+                             position: "absolute",
+                             top: "0",
+                             display: "flex",
+                             fontSize: "14px",
+                             alignItems: "flex-start",
+                             flexDirection: "column"
+                         }}
+                    >
+                        <FormControl
+                            required
+                            error={error}
+                            component="fieldset"
+                            sx={{m: 3}}
+                            variant="standard"
+                        >
+                            <FormLabel component="legend" style={{fontSize: "15px"}}>
+                                LEVEL VIEW: <span style={{fontWeight: "bold"}}>{levelView}</span>
+                            </FormLabel>
+                            <FormGroup>
+                                <FormControlLabel
+                                    control={
+                                        <Checkbox style={{transform: "scale(.8)"}} checked={communities} onChange={handleCheckBoxChange} name="communities"/>
+                                    }
+                                    label={<span style={{fontSize: "14px"}}>Communities Level</span>}
+                                />
+                                <FormControlLabel
+                                    control={
+                                        <Checkbox style={{transform: "scale(.8)"}} checked={hashtags} onChange={handleCheckBoxChange} name="hashtags"/>
+                                    }
+                                    label={<span style={{fontSize: "14px"}}>Hashtag Level</span>}
+                                />
+                                <FormControlLabel
+                                    control={
+                                        <Checkbox style={{transform: "scale(.75)"}} checked={topics} onChange={handleCheckBoxChange} name="topics"/>
+                                    }
+                                    label={<span style={{fontSize: "14px"}}>Topic Level</span>}
+                                />
+                                <FormControlLabel
+                                    control={
+                                        <Checkbox style={{transform: "scale(.75)"}} checked={metadescs} onChange={handleCheckBoxChange} name="metadescs"/>
+                                    }
+                                    label={<span style={{fontSize: "14px"}}>Meta-descriptor Level</span>}
+                                />
+                            </FormGroup>
+                            <FormHelperText>Please select at least one level to display</FormHelperText>
+                        </FormControl>
+                        <Button
+                            variant={"contained"}
+                            onClick={handleFilterOnClick}
+                            size="medium"
+                            endIcon={<FilterAltIcon />}
+                            style={{transform: "scale(0.75)"}}
+                        >
+                            Filter
+                        </Button>
+                    </Box>
                     <Paper elevation={0} id="graph-wrapper" style={{width: "inherit"}}>
                         {nodesById && <ForceTree data={graphData}/>}
                     </Paper>
@@ -344,7 +505,12 @@ const VisualizeMap = () => {
                                     {
                                         submissions["md_name"].length > 0 ?
                                             (
-                                                <h5>{submissions["md_name"].split("/")[1]} &#62; {submissions["md_name"].split("/")[2]} &#62; {submissions["md_name"].split("/")[3]}</h5>)
+                                                <h5>{!!submissions["md_name"].split("/")[1] && submissions["md_name"].split("/")[1]}
+                                                    {!!submissions["md_name"].split("/")[2] && " > " + submissions["md_name"].split("/")[2]}
+                                                    {!!submissions["md_name"].split("/")[3] && " > " + submissions["md_name"].split("/")[3]}
+                                                    {!!submissions["md_name"].split("/")[4] && " > " + submissions["md_name"].split("/")[4]}
+                                                </h5>
+                                            )
                                             :
                                             (<h5>Please select a Meta-descriptor of any topic to see related
                                                 submissions</h5>)
@@ -355,7 +521,12 @@ const VisualizeMap = () => {
                                         style={{height: height}}
                                         dataLength={submissions["submission_list"].length}
                                         loader="">
-                                        <Grid item style={{padding: "1%", display: "flex", flexDirection: "column", gap: "10px"}}>
+                                        <Grid item style={{
+                                            padding: "1%",
+                                            display: "flex",
+                                            flexDirection: "column",
+                                            gap: "10px"
+                                        }}>
                                             {submissions["submission_list"] !== undefined && submissions["submission_list"].length !== 0 &&
                                                 submissions["submission_list"].map(function (d, idx) {
                                                     return (
@@ -389,6 +560,11 @@ const VisualizeMap = () => {
             ) : (
                 "Loading..."
             )}
+            <Snackbar open={open} autoHideDuration={2000} onClose={handleClose}>
+                <Alert onClose={handleClose} severity={severity} sx={{ width: "100%" }}>
+                  {message}
+                </Alert>
+            </Snackbar>
             <Footer/>
         </>
     );


### PR DESCRIPTION
Type: `New Feature`

File changed:
- backend/app/helpers/topic_map.py
- backend/app/views/functional.py
- frontend/website/components/forms/communitybox.js
- frontend/website/components/forms/searchBarHeader.js
- frontend/website/components/visualizecomponent.js 

Description:
- Added level filters: Community, topics, hashtags and meta-descriptors to the visualize page.
- Based on the order these are selected, the graph is visualized.
- Handled the error when empty query is passed to the visualization page.
- Fixed the one-state delay issue for the level hierarchy. 