### PR TITLE
Handle unsaved changes

### DIFF
--- a/frontend/website/components/forms/submissionForm.js
+++ b/frontend/website/components/forms/submissionForm.js
@@ -28,7 +28,7 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import Box from '@mui/material/Box';
 import useSubmissionStore from "../../store/submissionStore";
 import { BASE_URL_CLIENT, BASE_URL_SERVER, GET_SUBMISSION_ENDPOINT } from "../../static/constants";
-import { CloseFullscreenOutlined, CloseOutlined } from "@mui/icons-material";
+import { CloseFullscreenOutlined, CloseOutlined, ElevatorSharp } from "@mui/icons-material";
 
 const MDEditor = dynamic(() => import("@uiw/react-md-editor"), { ssr: false });
 const baseURL_client = process.env.NEXT_PUBLIC_FROM_CLIENT + "api/";
@@ -85,11 +85,11 @@ export default function SubmissionForm(props) {
 
     const [isAnonymous, setAnonymous] = useState(props?.username == undefined)
 
-    const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+    // const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
     
-    const checkUnsavedChanges = () => {
-          setHasUnsavedChanges(true);
-      };
+    // const checkUnsavedChanges = () => {
+    //       setHasUnsavedChanges(true);
+    //   };
 
     const handleSnackbarClose = (event, reason) => {
         if (reason === "clickaway") {
@@ -350,34 +350,38 @@ export default function SubmissionForm(props) {
     };
 
     useEffect(() => { }, [submissionIncomingConnections]);
-    useEffect(() => { checkUnsavedChanges() } , [submissionTitle, submissionDescription, submissionSourceUrl, submissionIsAnonymous, submissionCommunity]);
-    useEffect(() => {
-        const handleRouteChangeStart = () => {
-            if (hasUnsavedChanges && !confirm('You have unsaved changes. Are you sure you want to leave?')) {
-                Router.events.emit('routeChangeError');
-                throw 'Abort route change. Please ignore this error.';
-            }
-        };
+    // useEffect(() => { checkUnsavedChanges() } , [submissionTitle, submissionDescription, submissionSourceUrl, submissionIsAnonymous, submissionCommunity]);
+    // useEffect(() => {
+    //     const handleRouteChangeStart = () => {
+    //         const userChoice = confirm('You have unsaved changes. Are you sure you want to leave?');
+    //         if (hasUnsavedChanges && !userChoice) {
+    //             Router.events.emit('routeChangeError');
+    //             throw 'Abort route change. Please ignore this error.';
+    //         }
+    //         if(userChoice){
+    //             Router.events.emit('')
+    //         }
+    //     };
 
-        Router.events.on('routeChangeStart', handleRouteChangeStart);
+    //     Router.events.on('routeChangeStart', handleRouteChangeStart);
 
-        return () => {
-            Router.events.off('routeChangeStart', handleRouteChangeStart);
-        };
-    }, [hasUnsavedChanges]);
-    useEffect(() => {
-        const handleBeforeUnload = (event) => {
-          if (hasUnsavedChanges) {
-            event.preventDefault();
-            event.returnValue = '';
-          }
-        };
-        window.addEventListener('beforeunload', handleBeforeUnload);
+    //     return () => {
+    //         Router.events.off('routeChangeStart', handleRouteChangeStart);
+    //     };
+    // }, [hasUnsavedChanges]);
+    // useEffect(() => {
+    //     const handleBeforeUnload = (event) => {
+    //       if (hasUnsavedChanges) {
+    //         event.preventDefault();
+    //         event.returnValue = '';
+    //       }
+    //     };
+    //     window.addEventListener('beforeunload', handleBeforeUnload);
       
-        return () => {
-          window.removeEventListener('beforeunload', handleBeforeUnload);
-        };
-      }, [hasUnsavedChanges]);
+    //     return () => {
+    //       window.removeEventListener('beforeunload', handleBeforeUnload);
+    //     };
+    //   }, [hasUnsavedChanges]);
 
     return (
 

--- a/frontend/website/components/header.js
+++ b/frontend/website/components/header.js
@@ -477,9 +477,6 @@ function Header(props) {
       setLoggedOut(false);
       console.log(e);
     }
-    
-    
-    //Router.push("/");
   };
 
   const handleUserClickMenu = (event, option) => {

--- a/frontend/website/components/header.js
+++ b/frontend/website/components/header.js
@@ -454,29 +454,13 @@ function Header(props) {
 
   const logout = async (event) => {
     event.preventDefault();
-    const A = jsCookie.get("token");
-    const B = localStorage.getItem("dropdowndata");
-
     jsCookie.remove("token");
     localStorage.removeItem("dropdowndata");
-
-    const C = communityData;
-    const D = userCommunities;
-    const E = username;
     setcommunityData([]);
     setUserDataStoreProps({ userCommunities: [] });
     setUserDataStoreProps({ username: [] });
     setLoggedOut(true);
-    try{
-      const w = await Router.push("/");
-    }catch(e){
-      jsCookie.set("token",A);
-      localStorage.setItem("dropdowndata",B);
-      setcommunityData(C);
-      setUserDataStoreProps({userCommunities: D, username: E});
-      setLoggedOut(false);
-      console.log(e);
-    }
+    Router.push("/");
   };
 
   const handleUserClickMenu = (event, option) => {

--- a/frontend/website/components/header.js
+++ b/frontend/website/components/header.js
@@ -454,15 +454,32 @@ function Header(props) {
 
   const logout = async (event) => {
     event.preventDefault();
+    const A = jsCookie.get("token");
+    const B = localStorage.getItem("dropdowndata");
+
     jsCookie.remove("token");
     localStorage.removeItem("dropdowndata");
 
+    const C = communityData;
+    const D = userCommunities;
+    const E = username;
     setcommunityData([]);
     setUserDataStoreProps({ userCommunities: [] });
     setUserDataStoreProps({ username: [] });
     setLoggedOut(true);
-
-    Router.push("/");
+    try{
+      const w = await Router.push("/");
+    }catch(e){
+      jsCookie.set("token",A);
+      localStorage.setItem("dropdowndata",B);
+      setcommunityData(C);
+      setUserDataStoreProps({userCommunities: D, username: E});
+      setLoggedOut(false);
+      console.log(e);
+    }
+    
+    
+    //Router.push("/");
   };
 
   const handleUserClickMenu = (event, option) => {

--- a/frontend/website/components/submissions/submissionDetails.js
+++ b/frontend/website/components/submissions/submissionDetails.js
@@ -532,7 +532,12 @@ export default function SubmissionDetails(subData) {
     }, []);
 
     useEffect(() => {
-        const handleRouteChangeStart = (event) => {
+        const handleRouteChangeStart = (url) => {
+            if(url == '/'){
+                console.log(`Route change to ${url} started`);
+                Router.events.off('routeChangeStart', handleRouteChangeStart);
+            } else {
+
             if (hasUnsavedChanges == true){
 
             if(!confirm('You have unsaved changes. Are you sure you want to leave?')) {
@@ -541,6 +546,7 @@ export default function SubmissionDetails(subData) {
                 throw 'Abort route change. Please ignore this error.';
                 }
             }
+        }
         };
 
         if(hasUnsavedChanges == false){

--- a/frontend/website/store/submissionStore.js
+++ b/frontend/website/store/submissionStore.js
@@ -30,7 +30,8 @@ const useSubmissionStore = create((set) => ({
     submissionSaveCommunityIDList: [],
 
     isAConnection: false,
-
+    hasUnsavedChanges: false,
+    //replySubHasUnsavedChanges: false,
     setSubmissionProps: (props) => set((state) => ({ ...state, ...props })),
 }));
 

--- a/frontend/website/store/submissionStore.js
+++ b/frontend/website/store/submissionStore.js
@@ -31,7 +31,6 @@ const useSubmissionStore = create((set) => ({
 
     isAConnection: false,
     hasUnsavedChanges: false,
-    //replySubHasUnsavedChanges: false,
     setSubmissionProps: (props) => set((state) => ({ ...state, ...props })),
 }));
 


### PR DESCRIPTION
We are tracking unsaved changes for the submission editor and the reply with mention editor.
For the submission editor, we are checking and maintaining a global variable hasUnsavedChanges.
For the reply with mention editor, we are checking and maintaining a local variable replySubHasUnsavedChanges.
Both <a></a> and Router.push cases have been handled.
The bug for popup coming after clicking on Save has been fixed.
The Logout bug has been handled as well. 